### PR TITLE
fix: Corrige error al filtrar categorias dentro de una jerarquia

### DIFF
--- a/modules/filtros.R
+++ b/modules/filtros.R
@@ -48,6 +48,7 @@ filtros_server <- function(id, opciones) {
     id = id,
     module = function(input, output, session) {
 
+      aplicar_count <- counter()
       # cantidad de filtros numericos
       n_num <- 3
       # cantidad de filtros de variables caracteres
@@ -184,6 +185,8 @@ filtros_server <- function(id, opciones) {
 
       observeEvent(aplicar_filtros(), {
         opciones$tabla <- opciones$tabla_original
+        # Variable global que cambia cada vez que se aplican los filtros
+        opciones$filtros_apply <- aplicar_count()
         inputs_filtros_char <- c()
         inputs_filtros_char <- unlist(
           lapply(

--- a/widgets/episodios_jerarquia_server.R
+++ b/widgets/episodios_jerarquia_server.R
@@ -67,7 +67,17 @@ episodios_jerarquia_server <- function(episodios, opciones, id = NULL,
     list(input$agrupador, input$episodios)
   })
 
-  observeEvent(cambio_columnas(), {
+  observe({
+    updateCheckboxInput(
+        inputId = "episodios",
+        value = FALSE
+      )
+  }) %>%
+  bindEvent(opciones$tabla_query)
+
+
+
+  observe({
     cache_id <- digest(
       object = list("agrup", cambio_columnas(), opciones$tabla_query),
       algo = "xxhash32",
@@ -112,7 +122,8 @@ episodios_jerarquia_server <- function(episodios, opciones, id = NULL,
     if (check_cache) {
       episodios$agrupadores_items <- opciones$cache[[cache_id]]
     }
-  })
+  }) %>%
+  bindEvent(cambio_columnas())
 
   observe({
     cambio_columnas()


### PR DESCRIPTION
Se corrige potencial error al filtrar categorias de una jerarquia de episodios previamente cargada.

El comportamiento ahora funciona de la siguiente manera:

Si se aplica un filtro, la jerarquia por episodios de desactivará. El usuario tendrá que volver a habilitarla.

Resuelve #6 

Signed-off-by: andres <afquinteromoreano@gmail.com>