### PR TITLE
fix: Corrige validación de nota técnica para inclusiones y exclusiones

### DIFF
--- a/json_schemas/nota_tecnica.json
+++ b/json_schemas/nota_tecnica.json
@@ -32,10 +32,10 @@
         "type": "string"
       },
       "exclusiones": {
-        "type": "array"
+        "type": ["array", "string"]
       },
       "inclusiones": {
-        "type": "array"
+        "type": ["array", "string"]
       },
       "agrupadores": {
         "type": "object",

--- a/man/cargar_datos.md
+++ b/man/cargar_datos.md
@@ -207,10 +207,10 @@ ingresará la clave determinada por el administrador de la aplicación.
         "type": "string"
       },
       "exclusiones": {
-        "type": "array"
+        "type": ["array", "string"]
       },
       "inclusiones": {
-        "type": "array"
+        "type": ["array", "string"]
       },
       "agrupadores": {
         "type": "object",


### PR DESCRIPTION
Se permiten arreglos y strings en el JSON de nota técnica para que el parser de V1 a V2 funcione.

resolves #5