### PR TITLE
Agrega paquete shinyCache

### DIFF
--- a/global.R
+++ b/global.R
@@ -52,6 +52,7 @@ library(listviewer)
 library(jsonvalidate)
 library(mapview)
 library(digest)
+library(shinyCache)
 
 # Si el administrador define el maxRequestSize en las variables de ambiente
 # entonces esta se utilizará. De esta manera se puede limitar cuantos

--- a/renv.lock
+++ b/renv.lock
@@ -831,6 +831,18 @@
       "Repository": "CRAN",
       "Hash": "402073a8a045c9f5ea096ed94e01d9ce"
     },
+    "shinyCache": {
+      "Package": "shinyCache",
+      "Version": "0.1.0",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "FundacionAIS",
+      "RemoteRepo": "shinyCache",
+      "RemoteRef": "v0.1.0",
+      "RemoteSha": "f4432236a7bcf9a6506b76bd60f7d8719a3aae4a",
+      "Hash": "d368e620eef4203a505ce83526d80256"
+    },
     "shinyWidgets": {
       "Package": "shinyWidgets",
       "Version": "0.6.0",


### PR DESCRIPTION
Se agrega el paquete shinyCache a al renv.lock y se llama desde el global.R

Adelanta issue #18 