### PR TITLE
Corrige error donde se suma valor no correspondiete a la nota técnica

### DIFF
--- a/R/completar_meses.R
+++ b/R/completar_meses.R
@@ -110,7 +110,8 @@ completar_meses <- function(
   # Se expande la tabla, los meses que previamente no estaban presentes quedan
   # como NA o "" dependiendo si es numérico o character
   data_completa <- data_original %>%
-    full_join(meses_completos)
+    full_join(meses_completos) %>%
+    filter(!is.na(ais_mes) || !is.na(ais_aio))
 
   return(data_completa)
 }


### PR DESCRIPTION
Resolves #24.

El error consistía de la manera en que se hacía join entre la nota técnica y la serie de tiempo. Ya este quedo corregido.

Para validar el funcionamieto cree una nota técnica ejemplo con la columna ambito de los datos didacticos:
```JSON
{
  "Ambito": {
    "poblacion": 35000,
    "prestador": "MD&CO Cali",
    "departamento": "Valle del Cauca",
    "cod_departamento": 76,
    "ciudades": "Cali, Palmira",
    "vigente": true,
    "agrupadores": {
      "AMBULATORIO": {
        "n": 504,
        "cm": 278714
      },
      "URGENCIAS": {
        "n": 153,
        "cm": 42235
      }
    }
  }
}
```

Resultado previo a corregir el error:
![image](https://user-images.githubusercontent.com/51521150/126400976-860c08bc-7af2-442d-ab76-f495f00284c8.png)

Resultado con este patch:
![image](https://user-images.githubusercontent.com/51521150/126401005-880710e1-3ccd-4ac3-a55e-4b725370cf95.png)
